### PR TITLE
Add SVD-based orthogonal subspace learning for continual learning

### DIFF
--- a/setup_model_for_training.py
+++ b/setup_model_for_training.py
@@ -101,8 +101,26 @@ def setup_model(model=None, orthogonal_subspace_learning: bool = False, **kwargs
             liger_fixed_fused_linear_cross_entropy_none_reduction,
         )
         from liger_kernel.transformers import AutoLigerKernelForCausalLM
-        model = AutoLigerKernelForCausalLM.from_pretrained(**base_model_args)
-        model = align_model_and_tokenizer(model, tokenizer)
+        if orthogonal_subspace_learning:
+            from svd_utils import create_svd_model_class, auto_generate_target_svd_config
+            tmp = AutoLigerKernelForCausalLM.from_pretrained(**base_model_args)
+            tmp = align_model_and_tokenizer(tmp, tokenizer)
+            svd_cfg = auto_generate_target_svd_config(tmp)
+            svd_cls = create_svd_model_class(tmp.__class__)
+            cfg = tmp.config
+            del tmp
+            torch.cuda.empty_cache()
+            model = svd_cls.from_pretrained(
+                **base_model_args,
+                config=cfg,
+                svd_config=svd_cfg,
+                initialize_svd=False,
+            )
+            model = align_model_and_tokenizer(model, tokenizer)
+            model.reinitialize_svd()
+        else:
+            model = AutoLigerKernelForCausalLM.from_pretrained(**base_model_args)
+            model = align_model_and_tokenizer(model, tokenizer)
     else:
         from none_reduction_losses import hf_fixed_cross_entropy_none_reduction
         patch_target_module(

--- a/svd_utils.py
+++ b/svd_utils.py
@@ -5,13 +5,22 @@ import numpy as np
 
 
 def decompose_weight_matrix(weight: torch.Tensor, top_k: int):
-    """Decompose a 2D weight matrix with SVD splitting the top ``top_k`` singular
-    components as frozen buffers and the rest as trainable parameters."""
-    device_local = weight.device
-    W = weight.to(torch.float32)
-    U, S, Vt = torch.linalg.svd(W, full_matrices=False)
-    k = min(top_k, S.shape[0])
+    """
+    Decomposes a 2D weight matrix into two components using Singular Value Decomposition (SVD):
+    - The top `top_k` singular components (U_high, S_high, V_high) are treated as frozen and encode
+      critical directions that should not be updated in new tasks.
+    - The remaining components (U_low, S_low, V_low) are made trainable and are used to learn new tasks.
 
+    This decomposition separates the weight space into high-rank subspaces for knowledge retention
+    and low-rank subspaces for task-specific adaptation, helping to mitigate catastrophic forgetting
+    in continual learning scenarios.
+    """
+    device_local = weight.device
+    W = weight.to(torch.float32)    # Ensure numerical stability for SVD
+    U, S, Vt = torch.linalg.svd(W, full_matrices=False)
+    k = min(top_k, S.shape[0])  # Cap to matrix rank
+
+    # Split high-rank (frozen) and low-rank (trainable) subspaces
     svd = {
         "U_high": U[:, :k].contiguous().detach().to(device=device_local),
         "S_high": S[:k].contiguous().detach().to(device=device_local),
@@ -19,13 +28,18 @@ def decompose_weight_matrix(weight: torch.Tensor, top_k: int):
         "U_low": nn.Parameter(U[:, k:].contiguous().detach().to(device=device_local)),
         "S_low": nn.Parameter(S[k:].contiguous().detach().to(device=device_local)),
         "V_low": nn.Parameter(Vt[k:, :].contiguous().detach().to(device=device_local)),
-        "rank_high": k,
+        "rank_high": k, # Store for later use in orthogonal projection
     }
     return svd
 
 
 def reconstruct_weight_matrix(svd_dict):
-    """Reconstruct the weight matrix from its SVD components."""
+    """
+    Reconstructs the original weight matrix from its SVD components.
+
+    Used for replacing linear layers during inference or forward pass to preserve the weight structure.
+    The final matrix is the sum of contributions from both the high-rank (frozen) and low-rank (trainable) components.
+    """
     U_high = svd_dict["U_high"]
     S_high = svd_dict["S_high"]
     V_high = svd_dict["V_high"]
@@ -33,11 +47,13 @@ def reconstruct_weight_matrix(svd_dict):
     S_low = svd_dict["S_low"]
     V_low = svd_dict["V_low"]
 
+    # Reconstruct high-rank component (frozen during continual learning)
     if U_high.numel() > 0 and S_high.numel() > 0:
         high_part = torch.mm(U_high * S_high.unsqueeze(0), V_high)
     else:
         high_part = torch.zeros(U_low.size(0), V_low.size(1), device=U_high.device)
 
+    # Reconstruct low-rank component (receives task-specific updates)
     if U_low.numel() > 0 and S_low.numel() > 0:
         low_part = torch.mm(U_low * S_low.unsqueeze(0), V_low)
     else:
@@ -47,8 +63,12 @@ def reconstruct_weight_matrix(svd_dict):
 
 
 def project_gradient_to_orthogonal_space(svd_dict):
-    """Project gradients of the low-rank subspace to be orthogonal to the high
-    subspace."""
+    """
+    Projects the gradient of the low-rank parameters (U_low, V_low) to be orthogonal to the frozen high-rank subspace.
+
+    This step ensures that learning new tasks does not interfere with previously learned representations by enforcing an orthogonality constraint.
+    """
+    # Skip if no gradients present (sanity check)
     if (
         svd_dict["U_low"].grad is None
         and svd_dict["S_low"].grad is None
@@ -59,11 +79,13 @@ def project_gradient_to_orthogonal_space(svd_dict):
     U_high = svd_dict["U_high"]
     V_high = svd_dict["V_high"]
 
+    # Project U_low gradients to space orthogonal to U_high
     if svd_dict["U_low"].grad is not None:
         dU = svd_dict["U_low"].grad
         # Support distributed tensors by operating on the local shard
         local_U_high = getattr(U_high, "to_local", lambda: U_high)()
         local_dU = getattr(dU, "to_local", lambda: dU)()
+        # Handle sharded tensors in distributed training
         if local_U_high.size(0) != local_dU.size(0):
             rank = torch.distributed.get_rank()
             start = rank * local_dU.size(0)
@@ -76,6 +98,7 @@ def project_gradient_to_orthogonal_space(svd_dict):
         else:
             dU.copy_(local_dU)
 
+    # Repeat projection for V_low using V_high
     if svd_dict["V_low"].grad is not None:
         dV = svd_dict["V_low"].grad
         local_V_high = getattr(V_high, "to_local", lambda: V_high)()
@@ -94,7 +117,12 @@ def project_gradient_to_orthogonal_space(svd_dict):
 
 
 def auto_generate_target_svd_config(model):
-    """Generate an SVD configuration for attention and MLP projection weights."""
+    """
+    Automatically selects which weight matrices (attention and MLP blocks) to decompose using SVD and determines their top-k values.
+
+    This heuristic uses 50% of the smaller dimension as the default top-k rank, ensuring preservation of
+    high-curvature directions while leaving the rest for adaptation.
+    """
     target_patterns = [
         "self_attn.q_proj",
         "self_attn.k_proj",
@@ -107,6 +135,7 @@ def auto_generate_target_svd_config(model):
     config = {}
     for name, param in model.named_parameters():
         if any(pat in name for pat in target_patterns) and len(param.shape) == 2:
+            # Use x% of effective rank heuristically
             top_k = int(np.floor(min(param.shape) * 0.5))
             full_rank = min(param.shape)
             if top_k >= full_rank:
@@ -116,23 +145,34 @@ def auto_generate_target_svd_config(model):
 
 
 def create_svd_model_class(base_cls):
-    """Dynamically create a subclass of ``base_cls`` that performs SVD based
-    decomposition on selected linear weights."""
+    """
+    Dynamically creates a subclass of the given `base_cls` that replaces selected linear weights
+    with low-rank + high-rank SVD-decomposed versions.
+
+    This class:
+    - Initializes frozen high-rank buffers and trainable low-rank parameters.
+    - Replaces the forward pass of targeted modules to use reconstructed weights.
+    - Projects gradients during training to enforce orthogonality with high-rank subspaces.
+
+    This class enables constrained full fine-tuning using adaptive SVD.
+    """
 
     class ModelWithSVD(base_cls):
         def __init__(self, config, svd_config=None, initialize_svd=True, **kwargs):
             super().__init__(config, **kwargs)
-            self.svd_config = svd_config or {}
+            self.svd_config = svd_config or {}  # Maps parameter names → top_k
             self.name_mapping = {}
-            self.svd_params = nn.ModuleDict()
+            self.svd_params = nn.ModuleDict()   # Stores low-rank trainable SVD components
             if initialize_svd:
                 self._initialize_svd_parameters()
 
         def reinitialize_svd(self):
+            """Reinitializes the decomposition (e.g., when learning a new task in continual learning)."""
             self.name_mapping = {}
             self.svd_params = nn.ModuleDict()
             self._initialize_svd_parameters()
         def _get_module_by_name(self, name):
+            """Helper to traverse and retrieve a module and its attribute by name string (e.g., `model.layers.0.attn.q_proj.weight`)."""
             parts = name.split(".")
             attr = parts[-1]
             mod = self
@@ -146,18 +186,29 @@ def create_svd_model_class(base_cls):
             return mod, attr
 
         def _initialize_svd_parameters(self):
+            """
+            Applies SVD decomposition to targeted parameters and replaces their forward logic.
+
+            This is the key transformation that enables constrained full-parameter updates by:
+            - Freezing high-rank components
+            - Training only low-rank ones
+            - Intercepting the forward pass to use the reconstructed matrix
+            """
             for name, param in list(self.named_parameters()):
+                # Apply SVD only to 2D matrices in the target config (e.g., q_proj, down_proj, etc.)
                 if len(param.shape) == 2 and name in self.svd_config and self.svd_config[name] > 0:
                     top_k = self.svd_config[name]
                     print(f"[SVD Init] Decomposing {name} with top_k={top_k}")
                     svd_dict = decompose_weight_matrix(param.data, top_k=top_k)
-                    safe_name = name.replace(".", "_")
+                    safe_name = name.replace(".", "_")  # Required for buffer/module naming in PyTorch
                     self.name_mapping[name] = safe_name
 
+                    # Freeze top-k singular directions (U/S/V_high)
                     self.register_buffer(f"{safe_name}_U_high", svd_dict["U_high"])
                     self.register_buffer(f"{safe_name}_S_high", svd_dict["S_high"])
                     self.register_buffer(f"{safe_name}_V_high", svd_dict["V_high"])
 
+                    # Wrapper to hold trainable components
                     module_svd = nn.Module()
                     module_svd.U_low = svd_dict["U_low"]
                     module_svd.S_low = svd_dict["S_low"]
@@ -169,6 +220,7 @@ def create_svd_model_class(base_cls):
                     mod, attr = self._get_module_by_name(name)
                     bias = mod.bias if hasattr(mod, "bias") else None
 
+                    # Override linear projection with dynamic reconstruction
                     def make_forward(sn, bias):
                         def forward(x):
                             W = self._reconstruct_weight_by_safe_name(sn)
@@ -179,9 +231,14 @@ def create_svd_model_class(base_cls):
 
                     mod.forward = make_forward(safe_name, bias)
                     param.requires_grad = False
+                    # Remove original parameter so it doesn't get updated
                     mod._parameters.pop(attr, None)
 
         def _reconstruct_weight_by_safe_name(self, safe_name):
+            """
+            Reconstructs a decomposed weight matrix from saved buffers + trainable low-rank parameters
+            to rebuild the full matrix used in forward.
+            """
             U_high = getattr(self, f"{safe_name}_U_high")
             S_high = getattr(self, f"{safe_name}_S_high")
             V_high = getattr(self, f"{safe_name}_V_high")
@@ -197,9 +254,16 @@ def create_svd_model_class(base_cls):
             return reconstruct_weight_matrix(svd_dict)
 
         def _reconstruct_weight(self, original_name):
+            """Convenience wrapper to reconstruct using the original parameter name."""
             return self._reconstruct_weight_by_safe_name(self.name_mapping[original_name])
 
         def project_gradients(self):
+            """
+            Applies orthogonal projection to gradients of low-rank components to avoid interfering
+            with the high-rank subspace encoding prior task knowledge.
+
+            This method should be called after backpropagation and before optimizer step.
+            """
             for safe_name, module_svd in self.svd_params.items():
                 svd_dict = {
                     "U_high": getattr(self, f"{safe_name}_U_high"),

--- a/svd_utils.py
+++ b/svd_utils.py
@@ -1,0 +1,197 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+import numpy as np
+
+
+def decompose_weight_matrix(weight: torch.Tensor, top_k: int):
+    """Decompose a 2D weight matrix with SVD splitting the top ``top_k`` singular
+    components as frozen buffers and the rest as trainable parameters."""
+    device_local = weight.device
+    W = weight.to(torch.float32)
+    U, S, Vt = torch.linalg.svd(W, full_matrices=False)
+    k = min(top_k, S.shape[0])
+
+    svd = {
+        "U_high": U[:, :k].detach().to(device=device_local),
+        "S_high": S[:k].detach().to(device=device_local),
+        "V_high": Vt[:k, :].detach().to(device=device_local),
+        "U_low": nn.Parameter(U[:, k:].detach().to(device=device_local)),
+        "S_low": nn.Parameter(S[k:].detach().to(device=device_local)),
+        "V_low": nn.Parameter(Vt[k:, :].detach().to(device=device_local)),
+        "rank_high": k,
+    }
+    return svd
+
+
+def reconstruct_weight_matrix(svd_dict):
+    """Reconstruct the weight matrix from its SVD components."""
+    U_high = svd_dict["U_high"]
+    S_high = svd_dict["S_high"]
+    V_high = svd_dict["V_high"]
+    U_low = svd_dict["U_low"]
+    S_low = svd_dict["S_low"]
+    V_low = svd_dict["V_low"]
+
+    if U_high.numel() > 0 and S_high.numel() > 0:
+        high_part = torch.mm(U_high * S_high.unsqueeze(0), V_high)
+    else:
+        high_part = torch.zeros(U_low.size(0), V_low.size(1), device=U_high.device)
+
+    if U_low.numel() > 0 and S_low.numel() > 0:
+        low_part = torch.mm(U_low * S_low.unsqueeze(0), V_low)
+    else:
+        low_part = torch.zeros(U_high.size(0), V_high.size(1), device=U_low.device)
+
+    return high_part + low_part
+
+
+def project_gradient_to_orthogonal_space(svd_dict):
+    """Project gradients of the low-rank subspace to be orthogonal to the high
+    subspace."""
+    if (
+        svd_dict["U_low"].grad is None
+        and svd_dict["S_low"].grad is None
+        and svd_dict["V_low"].grad is None
+    ):
+        return
+
+    U_high = svd_dict["U_high"]
+    V_high = svd_dict["V_high"]
+
+    if svd_dict["U_low"].grad is not None:
+        dU = svd_dict["U_low"].grad
+        proj = U_high @ (U_high.transpose(0, 1) @ dU)
+        dU.sub_(proj)
+
+    if svd_dict["V_low"].grad is not None:
+        dV = svd_dict["V_low"].grad
+        proj = (dV @ V_high.transpose(0, 1)) @ V_high
+        dV.sub_(proj)
+
+
+def auto_generate_target_svd_config(model):
+    """Generate an SVD configuration for attention and MLP projection weights."""
+    target_patterns = [
+        "self_attn.q_proj",
+        "self_attn.k_proj",
+        "self_attn.v_proj",
+        "self_attn.o_proj",
+        "mlp.gate_proj",
+        "mlp.down_proj",
+        "mlp.up_proj",
+    ]
+    config = {}
+    for name, param in model.named_parameters():
+        if any(pat in name for pat in target_patterns) and len(param.shape) == 2:
+            top_k = int(np.floor(min(param.shape) * 0.5))
+            full_rank = min(param.shape)
+            if top_k >= full_rank:
+                top_k = full_rank - 1
+            config[name] = top_k
+    return config
+
+
+def create_svd_model_class(base_cls):
+    """Dynamically create a subclass of ``base_cls`` that performs SVD based
+    decomposition on selected linear weights."""
+
+    class ModelWithSVD(base_cls):
+        def __init__(self, config, svd_config=None, initialize_svd=True, **kwargs):
+            super().__init__(config, **kwargs)
+            self.svd_config = svd_config or {}
+            self.name_mapping = {}
+            self.svd_params = nn.ModuleDict()
+            if initialize_svd:
+                self._initialize_svd_parameters()
+
+        def reinitialize_svd(self):
+            self.name_mapping = {}
+            self.svd_params = nn.ModuleDict()
+            self._initialize_svd_parameters()
+        def _get_module_by_name(self, name):
+            parts = name.split(".")
+            attr = parts[-1]
+            mod = self
+            for p in parts[:-1]:
+                if hasattr(mod, p):
+                    mod = getattr(mod, p)
+                elif p.isdigit():
+                    mod = mod[int(p)]
+                else:
+                    return None, None
+            return mod, attr
+
+        def _initialize_svd_parameters(self):
+            for name, param in list(self.named_parameters()):
+                if len(param.shape) == 2 and name in self.svd_config and self.svd_config[name] > 0:
+                    top_k = self.svd_config[name]
+                    svd_dict = decompose_weight_matrix(param.data, top_k=top_k)
+                    safe_name = name.replace(".", "_")
+                    self.name_mapping[name] = safe_name
+
+                    self.register_buffer(f"{safe_name}_U_high", svd_dict["U_high"])
+                    self.register_buffer(f"{safe_name}_S_high", svd_dict["S_high"])
+                    self.register_buffer(f"{safe_name}_V_high", svd_dict["V_high"])
+
+                    module_svd = nn.Module()
+                    module_svd.U_low = svd_dict["U_low"]
+                    module_svd.S_low = svd_dict["S_low"]
+                    module_svd.V_low = svd_dict["V_low"]
+                    module_svd.rank_high = svd_dict["rank_high"]
+                    module_svd.safe_name = safe_name
+                    self.svd_params[safe_name] = module_svd
+
+                    mod, attr = self._get_module_by_name(name)
+                    bias = mod.bias if hasattr(mod, "bias") else None
+
+                    def make_forward(sn, bias):
+                        def forward(x):
+                            W = self._reconstruct_weight_by_safe_name(sn)
+                            return F.linear(x, W, bias)
+                        return forward
+
+                    mod.forward = make_forward(safe_name, bias)
+                    param.requires_grad = False
+                    mod._parameters.pop(attr, None)
+
+        def _reconstruct_weight_by_safe_name(self, safe_name):
+            U_high = getattr(self, f"{safe_name}_U_high")
+            S_high = getattr(self, f"{safe_name}_S_high")
+            V_high = getattr(self, f"{safe_name}_V_high")
+            module_svd = self.svd_params[safe_name]
+            svd_dict = {
+                "U_high": U_high,
+                "S_high": S_high,
+                "V_high": V_high,
+                "U_low": module_svd.U_low,
+                "S_low": module_svd.S_low,
+                "V_low": module_svd.V_low,
+            }
+            return reconstruct_weight_matrix(svd_dict)
+
+        def _reconstruct_weight(self, original_name):
+            return self._reconstruct_weight_by_safe_name(self.name_mapping[original_name])
+
+        def project_gradients(self):
+            for safe_name, module_svd in self.svd_params.items():
+                svd_dict = {
+                    "U_high": getattr(self, f"{safe_name}_U_high"),
+                    "S_high": getattr(self, f"{safe_name}_S_high"),
+                    "V_high": getattr(self, f"{safe_name}_V_high"),
+                    "U_low": module_svd.U_low,
+                    "S_low": module_svd.S_low,
+                    "V_low": module_svd.V_low,
+                }
+                project_gradient_to_orthogonal_space(svd_dict)
+
+        # Bind helper methods to the class
+        ModelWithSVD._get_module_by_name = _get_module_by_name
+        ModelWithSVD._initialize_svd_parameters = _initialize_svd_parameters
+        ModelWithSVD._reconstruct_weight_by_safe_name = _reconstruct_weight_by_safe_name
+        ModelWithSVD._reconstruct_weight = _reconstruct_weight
+        ModelWithSVD.project_gradients = project_gradients
+
+    ModelWithSVD.__name__ = f"{base_cls.__name__}WithSVD"
+    return ModelWithSVD
+

--- a/train.py
+++ b/train.py
@@ -22,6 +22,8 @@ app = Typer(
 def take_gradient_step(model, optimizer, lr_scheduler):
     """Scales gradients, applies clipping, and takes an optimization step."""
     grad_norm = torch.nn.utils.clip_grad_norm_(model.parameters(), 1.0)
+    if hasattr(model, "project_gradients"):
+        model.project_gradients()
     optimizer.step()
     lr_scheduler.step()
     optimizer.zero_grad()
@@ -40,7 +42,16 @@ def save_model(fsdp_model, samples_seen, output_dir, model_name_or_path):
     # Get full state dict
     from torch.distributed.checkpoint.state_dict import get_model_state_dict, StateDictOptions
     state_dict = get_model_state_dict(fsdp_model, options=StateDictOptions(full_state_dict=True))
-    state_dict = {k:v.to(torch.bfloat16) for k,v in state_dict.items()}
+    inner = getattr(fsdp_model, "module", fsdp_model)
+    if hasattr(inner, "name_mapping"):
+        for orig, safe in inner.name_mapping.items():
+            W = inner._reconstruct_weight(orig).to(torch.bfloat16)
+            state_dict[orig] = W
+            for key in [f"{safe}_U_high", f"{safe}_S_high", f"{safe}_V_high"]:
+                state_dict.pop(key, None)
+            for sub in ["U_low", "S_low", "V_low"]:
+                state_dict.pop(f"svd_params.{safe}.{sub}", None)
+    state_dict = {k: v.to(torch.bfloat16) for k, v in state_dict.items()}
     
     if rank == 0:
         pattern = "model{suffix}.safetensors"
@@ -168,6 +179,7 @@ def main(
     lr_scheduler: str = Option("constant_with_warmup", help="Learning rate scheduler type"),
     seed: int = Option(42, help="Random seed for reproducibility"),
     use_liger_kernels: bool = Option(False, help="Whether to use Liger kernels"),
+    orthogonal_subspace_learning: bool = Option(False, help="Enable SVD based orthogonal subspace training"),
     output_dir: str = Option(..., help="Directory to save checkpoints and logs (required)"),
     logging_level: LogLevelEnum = Option(
         LogLevelEnum.INFO, 
@@ -193,6 +205,7 @@ def main(
             "lr_scheduler": lr_scheduler,
             "seed": seed,
             "use_liger_kernels": use_liger_kernels,
+            "orthogonal_subspace_learning": orthogonal_subspace_learning,
             "output_dir": output_dir,
             "logging_level": logging_level.value,
             "min_samples_per_checkpoint": min_samples_per_checkpoint,
@@ -207,8 +220,11 @@ def main(
         print(f"Training parameters saved to {params_path}")
 
     setup_logger(level=logging_level.value)
-    model = setup_model(model_name_or_path=model_name_or_path,
-                        use_liger_kernels=use_liger_kernels,)
+    model = setup_model(
+        model_name_or_path=model_name_or_path,
+        use_liger_kernels=use_liger_kernels,
+        orthogonal_subspace_learning=orthogonal_subspace_learning,
+    )
     model, optimizer, lr_scheduler = setup_training_components(model,
                                                                learning_rate=learning_rate,
                                                                num_warmup_steps=num_warmup_steps,


### PR DESCRIPTION
## Summary
- implement utilities in `svd_utils.py` for SVD decomposition and gradient projection
- extend `setup_model` to optionally initialize an SVD-enhanced model using these utilities
- call gradient projection in training loop and reconstruct weights when saving the model
- add CLI flag `--orthogonal-subspace-learning` to enable the feature
- support any causal LM class through dynamic subclassing
------