### PR TITLE
Add PEFT orthogonal subspace tuner

### DIFF
--- a/peft/__init__.py
+++ b/peft/__init__.py
@@ -1,0 +1,10 @@
+from .tuners import OrthogonalSubspaceConfig, OSLModel, OSLLinear
+from .utils.peft_types import PeftType, TaskType
+
+__all__ = [
+    "OrthogonalSubspaceConfig",
+    "OSLModel",
+    "OSLLinear",
+    "PeftType",
+    "TaskType",
+]

--- a/peft/tuners/__init__.py
+++ b/peft/tuners/__init__.py
@@ -1,0 +1,3 @@
+from .orthogonal import OrthogonalSubspaceConfig, OSLModel, OSLLinear
+
+__all__ = ["OrthogonalSubspaceConfig", "OSLModel", "OSLLinear"]

--- a/peft/tuners/orthogonal/__init__.py
+++ b/peft/tuners/orthogonal/__init__.py
@@ -1,0 +1,9 @@
+from peft.utils import register_peft_method
+
+from .config import OrthogonalSubspaceConfig
+from .model import OSLModel
+from .layer import OSLLinear
+
+__all__ = ["OrthogonalSubspaceConfig", "OSLModel", "OSLLinear"]
+
+register_peft_method(name="osl", config_cls=OrthogonalSubspaceConfig, model_cls=OSLModel)

--- a/peft/tuners/orthogonal/config.py
+++ b/peft/tuners/orthogonal/config.py
@@ -1,0 +1,15 @@
+from dataclasses import dataclass, field
+from typing import Dict, Optional
+
+from peft.config import PeftConfig
+from peft.utils import PeftType
+
+@dataclass
+class OrthogonalSubspaceConfig(PeftConfig):
+    """Configuration for orthogonal subspace learning adapters."""
+
+    svd_config: Optional[Dict[str, int]] = field(default_factory=dict, metadata={"help": "Parameter name to top_k."})
+    automatic_target: bool = field(default=True, metadata={"help": "Infer target modules automatically when True."})
+
+    def __post_init__(self):
+        self.peft_type = PeftType.OSL

--- a/peft/tuners/orthogonal/layer.py
+++ b/peft/tuners/orthogonal/layer.py
@@ -1,0 +1,49 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from .utils import decompose_weight_matrix, reconstruct_weight_matrix, project_gradient_to_orthogonal_space
+
+
+class OSLLinear(nn.Module):
+    """Linear layer with orthogonal subspace learning via SVD decomposition."""
+
+    def __init__(self, base_layer: nn.Linear, top_k: int):
+        super().__init__()
+        self.in_features = base_layer.in_features
+        self.out_features = base_layer.out_features
+        svd = decompose_weight_matrix(base_layer.weight.data, top_k)
+        self.register_buffer("U_high", svd["U_high"])
+        self.register_buffer("S_high", svd["S_high"])
+        self.register_buffer("V_high", svd["V_high"])
+        self.U_low = svd["U_low"]
+        self.S_low = svd["S_low"]
+        self.V_low = svd["V_low"]
+        self.bias = base_layer.bias
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        W = reconstruct_weight_matrix(
+            {
+                "U_high": self.U_high,
+                "S_high": self.S_high,
+                "V_high": self.V_high,
+                "U_low": self.U_low,
+                "S_low": self.S_low,
+                "V_low": self.V_low,
+            }
+        )
+        if W.dtype != x.dtype:
+            W = W.to(x.dtype)
+        return F.linear(x, W, self.bias)
+
+    def project_gradients(self):
+        project_gradient_to_orthogonal_space(
+            {
+                "U_high": self.U_high,
+                "S_high": self.S_high,
+                "V_high": self.V_high,
+                "U_low": self.U_low,
+                "S_low": self.S_low,
+                "V_low": self.V_low,
+            }
+        )

--- a/peft/tuners/orthogonal/model.py
+++ b/peft/tuners/orthogonal/model.py
@@ -1,0 +1,56 @@
+import torch
+import torch.nn as nn
+
+from peft.tuners.tuners_utils import BaseTuner
+
+from .config import OrthogonalSubspaceConfig
+from .layer import OSLLinear
+from .utils import auto_generate_target_svd_config
+
+
+class OSLModel(BaseTuner):
+    """Applies orthogonal subspace adapters to a pretrained model."""
+
+    prefix: str = "osl_"
+
+    def __init__(self, model, config: OrthogonalSubspaceConfig, adapter_name: str, low_cpu_mem_usage: bool = False):
+        super().__init__(model, config, adapter_name, low_cpu_mem_usage=low_cpu_mem_usage)
+
+    def _prepare_adapter_config(self, peft_config: OrthogonalSubspaceConfig, model_config: dict) -> OrthogonalSubspaceConfig:
+        if peft_config.automatic_target and not peft_config.svd_config:
+            peft_config.svd_config = auto_generate_target_svd_config(self.model)
+        return peft_config
+
+    def _check_target_module_exists(self, peft_config: OrthogonalSubspaceConfig, key: str) -> bool:
+        return key in peft_config.svd_config
+
+    def _create_and_replace(self, peft_config: OrthogonalSubspaceConfig, adapter_name: str, target: nn.Module, target_name: str, parent: nn.Module, current_key: str) -> None:
+        top_k = peft_config.svd_config[current_key]
+        if isinstance(target, nn.Linear):
+            new_module = OSLLinear(target, top_k)
+            setattr(parent, target_name, new_module)
+            self.targeted_module_names.append(current_key)
+
+    def _mark_only_adapters_as_trainable(self, model: nn.Module):
+        for n, p in model.named_parameters():
+            p.requires_grad = False
+        for module in model.modules():
+            if isinstance(module, OSLLinear):
+                module.U_low.requires_grad = True
+                module.S_low.requires_grad = True
+                module.V_low.requires_grad = True
+
+    def disable_adapter_layers(self) -> None:
+        for module in self.model.modules():
+            if isinstance(module, OSLLinear):
+                module.requires_grad_(False)
+
+    def enable_adapter_layers(self) -> None:
+        for module in self.model.modules():
+            if isinstance(module, OSLLinear):
+                module.requires_grad_(True)
+
+    def project_gradients(self):
+        for module in self.model.modules():
+            if isinstance(module, OSLLinear):
+                module.project_gradients()

--- a/peft/tuners/orthogonal/utils.py
+++ b/peft/tuners/orthogonal/utils.py
@@ -1,0 +1,79 @@
+import torch
+import torch.nn as nn
+
+
+def decompose_weight_matrix(weight: torch.Tensor, top_k: int):
+    device_local = weight.device
+    orig_dtype = weight.dtype
+    W = weight.to(torch.float32)
+    U, S, Vt = torch.linalg.svd(W, full_matrices=False)
+    k = min(top_k, S.shape[0])
+    svd = {
+        "U_high": U[:, :k].contiguous().detach().to(device=device_local, dtype=orig_dtype),
+        "S_high": S[:k].contiguous().detach().to(device=device_local, dtype=orig_dtype),
+        "V_high": Vt[:k, :].contiguous().detach().to(device=device_local, dtype=orig_dtype),
+        "U_low": nn.Parameter(U[:, k:].contiguous().detach().to(device=device_local, dtype=orig_dtype)),
+        "S_low": nn.Parameter(S[k:].contiguous().detach().to(device=device_local, dtype=orig_dtype)),
+        "V_low": nn.Parameter(Vt[k:, :].contiguous().detach().to(device=device_local, dtype=orig_dtype)),
+    }
+    return svd
+
+
+def reconstruct_weight_matrix(svd_dict):
+    U_high = svd_dict["U_high"]
+    S_high = svd_dict["S_high"]
+    V_high = svd_dict["V_high"]
+    U_low = svd_dict["U_low"]
+    S_low = svd_dict["S_low"]
+    V_low = svd_dict["V_low"]
+
+    high_part = torch.mm(U_high * S_high.unsqueeze(0), V_high) if S_high.numel() > 0 else 0
+    low_part = torch.mm(U_low * S_low.unsqueeze(0), V_low) if S_low.numel() > 0 else 0
+    return high_part + low_part
+
+
+def project_gradient_to_orthogonal_space(svd_dict):
+    if all((svd_dict[name].grad is None for name in ["U_low", "S_low", "V_low"])):
+        return
+    U_high = svd_dict["U_high"]
+    V_high = svd_dict["V_high"]
+    if svd_dict["U_low"].grad is not None:
+        dU = svd_dict["U_low"].grad
+        proj = U_high @ (U_high.transpose(0, 1) @ dU)
+        dU.sub_(proj)
+    if svd_dict["V_low"].grad is not None:
+        dV = svd_dict["V_low"].grad
+        proj = (dV @ V_high.transpose(0, 1)) @ V_high
+        dV.sub_(proj)
+
+
+def auto_generate_target_svd_config(model):
+    patterns = [
+        "q_proj",
+        "k_proj",
+        "v_proj",
+        "o_proj",
+        "gate_proj",
+        "down_proj",
+        "up_proj",
+    ]
+    config = {}
+    for name, param in model.named_parameters():
+        if any(p in name for p in patterns) and len(param.shape) == 2:
+            top_k = int(min(param.shape) * 0.5)
+            full_rank = min(param.shape)
+            if top_k >= full_rank:
+                top_k = full_rank - 1
+            config[name] = top_k
+    return config
+
+
+def optim_wrapper(optimizer, model):
+    if not hasattr(model, "project_gradients"):
+        return optimizer
+    orig_step = optimizer.step
+    def step(*args, **kwargs):
+        model.project_gradients()
+        return orig_step(*args, **kwargs)
+    optimizer.step = step
+    return optimizer

--- a/peft/utils/peft_types.py
+++ b/peft/utils/peft_types.py
@@ -1,0 +1,41 @@
+import enum
+from typing import Optional
+
+
+class PeftType(str, enum.Enum):
+    """Enum class for the different types of adapters in PEFT."""
+
+    PROMPT_TUNING = "PROMPT_TUNING"
+    MULTITASK_PROMPT_TUNING = "MULTITASK_PROMPT_TUNING"
+    P_TUNING = "P_TUNING"
+    PREFIX_TUNING = "PREFIX_TUNING"
+    LORA = "LORA"
+    ADALORA = "ADALORA"
+    BOFT = "BOFT"
+    ADAPTION_PROMPT = "ADAPTION_PROMPT"
+    IA3 = "IA3"
+    LOHA = "LOHA"
+    LOKR = "LOKR"
+    OFT = "OFT"
+    POLY = "POLY"
+    LN_TUNING = "LN_TUNING"
+    VERA = "VERA"
+    FOURIERFT = "FOURIERFT"
+    XLORA = "XLORA"
+    HRA = "HRA"
+    VBLORA = "VBLORA"
+    CPT = "CPT"
+    BONE = "BONE"
+    RANDLORA = "RANDLORA"
+    TRAINABLE_TOKENS = "TRAINABLE_TOKENS"
+    C3A = "C3A"
+    OSL = "OSL"
+
+
+class TaskType(str, enum.Enum):
+    """Enum class for the different task types supported by PEFT."""
+
+    SEQ_CLS = "SEQ_CLS"
+    SEQ_2_SEQ_LM = "SEQ_2_SEQ_LM"
+    CAUSAL_LM = "CAUSAL_LM"
+


### PR DESCRIPTION
## Summary
- add a minimal orthogonal subspace learning tuner mirroring PEFT layout
- implement SVD based OSL linear layer and model
- expose `OSL` PEFT type

## Testing
- `python - <<'PY'
import peft
from peft.tuners.orthogonal import OrthogonalSubspaceConfig
print('config class:', OrthogonalSubspaceConfig.__name__)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68752076f74083288951d898fabb3134