### PR TITLE
simplify implementation of memory efficient + GPT-OSS loading

### DIFF
--- a/src/mini_trainer/osft_utils.py
+++ b/src/mini_trainer/osft_utils.py
@@ -393,7 +393,6 @@ def reconstruct_weight_matrix(
         reconstructed = reconstructed.to(output_dtype)
     return reconstructed
 
-
 def project_gradient_to_orthogonal_space(svd_dict: SVDDecompositionDict):
     """
     Projects the gradient of the low-rank parameters (U_low, V_low) to be orthogonal to the frozen high-rank subspace.
@@ -699,7 +698,10 @@ def _load_model_memory_efficient(
     osft_memory_efficient_init: bool = False
 ):
     """
-    Memory-efficient loading for GPT-OSS models to avoid CUDA OOM.
+    Memory-efficient loading for OSFT models to avoid CUDA OOM.
+    
+    This function loads models to CPU first, extracts state dict, then creates
+    the OSFT model to minimize peak memory usage during initialization.
     
     Args:
         actual_osft_cls: The OSFT model class to instantiate
@@ -729,13 +731,17 @@ def _load_model_memory_efficient(
     # Remove additional OSFT parameters before calling base model's from_pretrained
     final_base_kwargs = _filter_osft_parameters(base_kwargs, OSFT_BASE_MODEL_FILTERED_PARAMS)
     
-    # Force CPU loading and lower precision to minimize memory usage
-    final_base_kwargs['torch_dtype'] = torch.bfloat16
+    # Force CPU loading and use the train_dtype for consistency with FSDP2
+    # Need to get train_dtype from base_kwargs or default to float32
+    load_dtype = base_kwargs.get('torch_dtype', None)
+    if load_dtype is None:
+        raise ValueError("error: model does not have a `torch_dtype` setting, please report this to the developers")
+    final_base_kwargs['torch_dtype'] = load_dtype
     final_base_kwargs['device_map'] = 'cpu'
     
     # Load base model to CPU only and extract what we need immediately
     with torch.no_grad():
-        log_rank_0("📥 Loading base model to CPU...")
+        log_rank_0(f"📥 Loading base model to CPU in {load_dtype}...")
         base_model = base_model_class.from_pretrained(
             pretrained_model_name_or_path,
             *model_args,
@@ -763,60 +769,50 @@ def _load_model_memory_efficient(
         osft_memory_efficient_init=osft_memory_efficient_init
     )
     
-    # Load state dict into OSFT model
-    log_rank_0("📋 Loading state dict into OSFT model...")
-    model.load_state_dict(state_dict, strict=False)
+    if osft_memory_efficient_init:
+        # Memory-efficient loading: process parameters individually
+        log_rank_0("📋 Loading state dict with memory-efficient OSFT processing...")
+        
+        # Load non-OSFT parameters normally first
+        non_osft_state = {}
+        osft_params = []
+        
+        for name, param in state_dict.items():
+            if hasattr(model, 'osft_config') and is_osft_param(name, param, model.osft_config):
+                # Store OSFT parameters for individual processing
+                osft_params.append((name, param))
+            else:
+                # Load non-OSFT parameters normally
+                non_osft_state[name] = param
+        
+        # Load non-OSFT parameters first
+        if non_osft_state:
+            model.load_state_dict(non_osft_state, strict=False)
+            del non_osft_state
+        
+        # Process OSFT parameters individually with memory-efficient initialization
+        if osft_params:
+            model.reinitialize_osft(decompose_existing_weights=True, assigned_params=osft_params)
+        
+        # Clear the full state dict
+        del state_dict
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
+    else:
+        # Standard loading: load everything then initialize OSFT
+        log_rank_0("📋 Loading state dict into OSFT model...")
+        model.load_state_dict(state_dict, strict=False)
+        
+        # Clear state dict memory
+        del state_dict
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
     
-    # Clear state dict memory
-    del state_dict
-    if torch.cuda.is_available():
-        torch.cuda.empty_cache()
     log_rank_0("✅ OSFT model created successfully with memory optimization")
     
     return model
 
 
-def _load_gpt_oss_model(
-    cls,
-    pretrained_model_name_or_path: str,
-    model_args: tuple,
-    kwargs: dict,
-    init_cfg: dict,
-    osft_memory_efficient_init: bool = False
-):
-    """
-    Load GPT-OSS model with OSFT support using parameter filtering and memory optimization.
-    
-    Args:
-        cls: The OSFT model class
-        pretrained_model_name_or_path: Model path or name
-        model_args: Positional arguments
-        kwargs: All keyword arguments
-        init_cfg: OSFT configuration
-        osft_memory_efficient_init: Whether to use memory-efficient SVD initialization
-        
-    Returns:
-        Loaded OSFT model
-    """
-    log_rank_0("🎯 Detected GPT-OSS model - using standard OSFT loading with parameter filtering")
-    
-    # Step 1: Filter parameters and extract OSFT class-specific kwargs
-    osft_class_kwargs, filtered_kwargs = _extract_osft_class_kwargs(kwargs)
-    base_kwargs = _filter_osft_parameters(filtered_kwargs, OSFT_GPT_OSS_FILTERED_PARAMS)
-    
-    # Step 2: Create OSFT class from GptOssForCausalLM directly
-    actual_osft_cls = create_osft_model_class(GptOssForCausalLM)
-    
-    # Step 3: Use memory-efficient loading
-    return _load_model_memory_efficient(
-        actual_osft_cls,
-        pretrained_model_name_or_path,
-        model_args,
-        base_kwargs,
-        init_cfg,
-        osft_class_kwargs,
-        osft_memory_efficient_init
-    )
 
 
 def _build_osft_kwargs(osft_rank_ratio, osft_target_patterns):
@@ -878,83 +874,6 @@ def _initialize_osft_with_distribution(model):
     return model
 
 
-
-
-def setup_osft_model(
-    model_class,
-    base_model_args: dict,
-    tokenizer,
-    is_gpt_oss: bool,
-    rank: int,
-    osft_rank_ratio=None,
-    osft_target_patterns=None,
-    osft_upcast_dtype=torch.float32,
-    osft_output_dtype=None,
-    osft_memory_efficient_init: bool = False,
-):
-    """
-    High-level function to set up an OSFT model with all necessary configuration.
-    
-    This function handles both GPT-OSS and standard model paths, eliminating
-    duplication and centralizing all OSFT-specific logic.
-    
-    Args:
-        model_class: The base model class to use
-        base_model_args: Arguments for model loading
-        tokenizer: Tokenizer for model alignment
-        is_gpt_oss: Whether this is a GPT-OSS model
-        rank: Current process rank
-        osft_rank_ratio: Rank ratio for OSFT decomposition
-        osft_target_patterns: Target patterns for OSFT
-        osft_upcast_dtype: Upcast dtype for OSFT computations
-        osft_output_dtype: Output dtype for OSFT results
-        osft_memory_efficient_init: Whether to use memory-efficient SVD initialization
-        
-    Returns:
-        Fully configured and initialized OSFT model
-    """
-    from mini_trainer.setup_model_for_training import align_model_and_tokenizer
-    
-    osft_kwargs = _build_osft_kwargs(osft_rank_ratio, osft_target_patterns)
-    
-    if is_gpt_oss:
-        # GPT-OSS: Direct OSFT model loading with parameter filtering handled internally
-        osft_cls = create_osft_model_class(model_class)
-        model: OSFTModel = osft_cls.from_pretrained(
-            **base_model_args,
-            initialize_osft=False,
-            osft_memory_efficient_init=osft_memory_efficient_init,
-            **osft_kwargs,
-        )
-        model = align_model_and_tokenizer(model, tokenizer)
-        
-    else:
-        # Standard models: Load base model first, then create OSFT class
-        tmp = model_class.from_pretrained(**base_model_args)
-        tmp = align_model_and_tokenizer(tmp, tokenizer)
-        osft_cls = create_osft_model_class(tmp.__class__)
-        cfg = tmp.config
-        del tmp
-        torch.cuda.empty_cache()
-        
-        model: OSFTModel = osft_cls.from_pretrained(
-            **base_model_args,
-            config=cfg,
-            initialize_osft=False,
-            osft_memory_efficient_init=osft_memory_efficient_init,
-            **osft_kwargs,
-        )
-        model = align_model_and_tokenizer(model, tokenizer)
-        
-        # Move standard models to GPU immediately
-        device = torch.device("cuda", rank)
-        model = model.to(device)
-    
-    # Set OSFT dtype attributes (common for both paths)
-    _set_osft_dtypes(model, osft_upcast_dtype, osft_output_dtype)
-    
-    # Initialize OSFT decomposition
-    return _initialize_osft_with_distribution(model)
 
 
 def create_osft_model_class(base_cls) -> type[OSFTModel]:
@@ -1023,7 +942,14 @@ def create_osft_model_class(base_cls) -> type[OSFTModel]:
             osft_memory_efficient_init: bool = False,
             **kwargs
         ) -> type[OSFTModel]:
-            """Load pretrained weights and automatically initialize OSFT parameters."""
+            """Load pretrained weights and automatically initialize OSFT parameters.
+            
+            Args:
+                osft_memory_efficient_init: If True, uses memory-efficient loading that loads
+                    the model to CPU first, extracts state dict, then creates OSFT model.
+                    This reduces peak memory usage but may be slower. Useful for large models
+                    when GPU memory is limited. Default is False for all models.
+            """
             init_cfg = osft_config if osft_config is not None else {}
             log_rank_0("\033[33m!!!! Calling from_pretrained !!!!\033[0m")
             initialize_osft = kwargs.pop('initialize_osft', False)
@@ -1033,14 +959,36 @@ def create_osft_model_class(base_cls) -> type[OSFTModel]:
             temp_config = AutoConfig.from_pretrained(pretrained_model_name_or_path, trust_remote_code=True)
             is_gpt_oss = is_gpt_oss_model(temp_config)
             
+            # Extract OSFT class-specific kwargs
+            osft_class_kwargs, filtered_kwargs = _extract_osft_class_kwargs(kwargs)
+            
+            # Apply model-specific parameter filtering
             if is_gpt_oss:
-                model = _load_gpt_oss_model(cls, pretrained_model_name_or_path, model_args, kwargs, init_cfg, osft_memory_efficient_init)
+                base_kwargs = _filter_osft_parameters(filtered_kwargs, OSFT_GPT_OSS_FILTERED_PARAMS)
+                # For GPT-OSS, we need to use the specific model class
+                actual_osft_cls = create_osft_model_class(GptOssForCausalLM)
             else:
-                # Standard model loading path
-                base_kwargs = kwargs.copy()
+                base_kwargs = filtered_kwargs.copy()
                 base_kwargs['osft_config'] = init_cfg
                 base_kwargs['initialize_osft'] = False
-                
+                actual_osft_cls = cls
+            
+            # Decide loading strategy based on memory_efficient_init flag
+            if osft_memory_efficient_init:
+                # Use memory-efficient loading only when explicitly requested
+                log_rank_0(f"🧠 Using memory-efficient loading (explicitly requested)")
+                model = _load_model_memory_efficient(
+                    actual_osft_cls,
+                    pretrained_model_name_or_path,
+                    model_args,
+                    base_kwargs,
+                    init_cfg,
+                    osft_class_kwargs,
+                    osft_memory_efficient_init
+                )
+            else:
+                # Standard loading path (default for all models including GPT-OSS)
+                log_rank_0(f"⚡ Using standard model loading (model_type: {'gpt_oss' if is_gpt_oss else 'standard'})")
                 model = super(ModelWithOSFT, cls).from_pretrained(
                     pretrained_model_name_or_path,
                     *model_args,
@@ -1233,13 +1181,11 @@ def create_osft_model_class(base_cls) -> type[OSFTModel]:
 
             log_rank_0("\033[33m!!!! Initializing OSFT Params!!!!\033[0m")
             
-            # Check if this is a memory-constrained scenario
+            # Set up target device for memory-efficient operations
             local_rank = int(os.getenv("LOCAL_RANK", 0))
             target_device = torch.device("cuda", local_rank) if torch.cuda.is_available() else torch.device("cpu")
-            is_memory_constrained = (next(self.parameters()).device.type == 'cpu' and
-                                   target_device.type == 'cuda')
             
-            if self.osft_memory_efficient_init and is_memory_constrained:
+            if self.osft_memory_efficient_init:
                 log_rank_0(f"🧠 Using ultra-memory-efficient OSFT initialization for device {target_device}")
             
             for name, param in named_params:
@@ -1247,7 +1193,7 @@ def create_osft_model_class(base_cls) -> type[OSFTModel]:
                 if is_osft_param(name, param, self.osft_config):
                     top_k = self.osft_config[name]
                     
-                    if self.osft_memory_efficient_init and is_memory_constrained:
+                    if self.osft_memory_efficient_init:
                         # Memory monitoring before processing
                         if torch.cuda.is_available():
                             mem_before = torch.cuda.memory_allocated(target_device) / 1e9

--- a/src/mini_trainer/setup_model_for_training.py
+++ b/src/mini_trainer/setup_model_for_training.py
@@ -8,9 +8,9 @@ from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
     checkpoint_wrapper as ptd_checkpoint_wrapper,
 )
 from torch.distributed.device_mesh import init_device_mesh
-from transformers import AutoTokenizer, AutoModelForCausalLM, AutoConfig
-from mini_trainer.utils import log_rank_0, patch_target_module
-from mini_trainer.osft_utils import OSFTModel, setup_osft_model
+from transformers import AutoTokenizer, AutoModelForCausalLM, AutoConfig, Mxfp4Config
+from mini_trainer.utils import get_model_class_from_config, log_rank_0, patch_target_module
+from mini_trainer.osft_utils import OSFTModel, _build_osft_kwargs, _initialize_osft_with_distribution, _set_osft_dtypes, create_osft_model_class
 from mini_trainer.gpt_oss_utils import freeze_router_params, is_gpt_oss_model
 
 
@@ -165,6 +165,93 @@ def get_model_save_dtype(save_dtype: str | torch.dtype | None, model_name_or_pat
     return save_dtype
 
 
+def setup_osft_model(
+    model_class,
+    model_name_or_path: str,
+    base_model_args: dict,
+    tokenizer,
+    is_gpt_oss: bool,
+    rank: int,
+    osft_rank_ratio=None,
+    osft_target_patterns=None,
+    osft_upcast_dtype=torch.float32,
+    osft_output_dtype=None,
+    osft_memory_efficient_init: bool = False,
+):
+    """
+    High-level function to set up an OSFT model with all necessary configuration.
+
+    This function handles both GPT-OSS and standard model paths with minimal
+    duplication.
+
+    Args:
+        model_class: The base model class to use
+        base_model_args: Arguments for model loading
+        tokenizer: Tokenizer for model alignment
+        is_gpt_oss: Whether this is a GPT-OSS model
+        rank: Current process rank
+        osft_rank_ratio: Rank ratio for OSFT decomposition
+        osft_target_patterns: Target patterns for OSFT
+        osft_upcast_dtype: Upcast dtype for OSFT computations
+        osft_output_dtype: Output dtype for OSFT results
+        osft_memory_efficient_init: Whether to use memory-efficient SVD initialization
+
+    Returns:
+        Fully configured and initialized OSFT model
+    """
+    from mini_trainer.setup_model_for_training import align_model_and_tokenizer
+
+    osft_kwargs = _build_osft_kwargs(osft_rank_ratio, osft_target_patterns)
+
+    # Determine the actual model class and config
+    actual_model_class = get_model_class_from_config(model_name_or_path)
+    config = None
+    if not is_gpt_oss:
+        # Standard models need to load a temporary model to get the actual class
+        tmp = model_class.from_pretrained(**base_model_args)
+
+        # GPT-OSS doesn't need to pull the config, but all other models do (for now, anyway)
+        config = tmp.config
+        del tmp
+        torch.cuda.empty_cache()
+
+    # Create OSFT model class and load model
+    osft_cls = create_osft_model_class(actual_model_class)
+    model_load_args = {
+        **base_model_args,
+        "initialize_osft": False,
+        "osft_memory_efficient_init": osft_memory_efficient_init,
+        **osft_kwargs,
+    }
+
+    # Add config for non-GPT-OSS models
+    if config is not None:
+        model_load_args["config"] = config
+
+    model: OSFTModel = osft_cls.from_pretrained(**model_load_args)
+    model = align_model_and_tokenizer(model, tokenizer)
+
+    # Set OSFT dtype attributes
+    _set_osft_dtypes(model, osft_upcast_dtype, osft_output_dtype)
+
+    # Handle initialization based on memory_efficient_init flag
+    device = torch.device("cuda", rank)
+
+    if osft_memory_efficient_init:
+        # Memory-efficient: Initialize OSFT on CPU, then move to GPU
+        log_rank_0("🧠 Using memory-efficient OSFT initialization (CPU → GPU)")
+        model = _initialize_osft_with_distribution(model)
+        log_rank_0("Initialized OSFT model, keeping on CPU until sharding")
+
+    else:
+        # Standard: Move to GPU first, then initialize OSFT on GPU
+        log_rank_0("⚡ Using standard OSFT initialization (GPU-native)")
+        model = model.to(device)
+        model = _initialize_osft_with_distribution(model)
+
+    return model
+
+
 def setup_model(
     model_name_or_path: str,
     osft: bool = False,
@@ -180,6 +267,7 @@ def setup_model(
 ) -> torch.nn.Module | OSFTModel:
     base_model_args = {
         "pretrained_model_name_or_path": model_name_or_path,
+        "torch_dtype": train_dtype,  # Ensure models are loaded in the training dtype
     }
     
     # Get model config to check for GPT-OSS and set appropriate configurations
@@ -189,8 +277,11 @@ def setup_model(
     # Set up quantization config for GPT-OSS models
     if is_gpt_oss:
         try:
-            from transformers import Mxfp4Config
-            base_model_args["quantization_config"] = Mxfp4Config(dequantize=True)
+            # Try to specify the target dtype for dequantization
+            quantization_config = Mxfp4Config(dequantize=True)
+            # If the config supports dtype specification, use it
+            if hasattr(quantization_config, 'torch_dtype'):
+                quantization_config.torch_dtype = train_dtype
             log_rank_0("🎯 Detected GPT-OSS model - applying dequantization for training")
         except ImportError:
             log_rank_0("⚠️ GPT-OSS model detected but Mxfp4Config not available - using default config")
@@ -240,6 +331,7 @@ def setup_model(
         effective_osft_output_dtype = osft_output_dtype if osft_output_dtype is not None else train_dtype
         return setup_osft_model(
             model_class=ModelClass,
+            model_name_or_path=model_name_or_path,
             base_model_args=base_model_args,
             tokenizer=tokenizer,
             is_gpt_oss=is_gpt_oss,
@@ -264,14 +356,16 @@ def setup_model(
         freeze_router_params(model)
     
     # Convert all trainable parameters to specified training dtype
-    if not osft:
-        log_rank_0(f"🔧 Converting trainable parameters to {train_dtype} for training")
-        converted_count = 0
-        for name, param in model.named_parameters():
-            if param.requires_grad and param.dtype != train_dtype:
-                param.data = param.data.to(train_dtype)
-                converted_count += 1
-        log_rank_0(f"✅ Converted {converted_count} trainable parameters to {train_dtype}")
+    log_rank_0(f"🔧 Converting trainable parameters to {train_dtype} for training")
+    converted_count = 0
+    for name, param in model.named_parameters():
+        if param.requires_grad and param.dtype != train_dtype:
+            param.data = param.data.to(train_dtype)
+            converted_count += 1
+    if converted_count > 0:
+        log_rank_0(f"✅ Converted {converted_count} parameters to {train_dtype}")
+    else:
+        log_rank_0(f"✅ All parameters already in {train_dtype}")
 
     # Get the base class name (strip WithOSFT suffix if present for OSFT models)
     class_name = model.__class__.__name__

--- a/src/mini_trainer/train.py
+++ b/src/mini_trainer/train.py
@@ -499,6 +499,7 @@ def train(
                 batch_time = time.time() - batch_start_time
                 batch_metrics = {
                         "step": step,
+                        "epoch": epoch,
                         "lr": lr_scheduler.get_last_lr()[0],
                         "grad_norm": grad_norm.item(),
                         "loss": bm['loss']/batch_num_loss_counted_tokens,
@@ -711,6 +712,7 @@ def main(
             "output_dir": output_dir,
             "min_samples_per_checkpoint": min_samples_per_checkpoint,
             "save_dtype": save_dtype,
+            "train_dtype": train_dtype,
             "training_mode": training_mode.value,
             "max_epochs": max_epochs,
             "max_steps": max_steps,
@@ -731,10 +733,9 @@ def main(
     setup_logger(level="INFO")
 
     # Parse scheduler kwargs from JSON string
-    import json as json_module
     try:
-        scheduler_kwargs_dict = json_module.loads(lr_scheduler_kwargs) if lr_scheduler_kwargs else {}
-    except json_module.JSONDecodeError:
+        scheduler_kwargs_dict = json.loads(lr_scheduler_kwargs) if lr_scheduler_kwargs else {}
+    except json.JSONDecodeError:
         log_rank_0(f"Warning: Invalid JSON for lr_scheduler_kwargs: {lr_scheduler_kwargs}. Using empty dict.")
         scheduler_kwargs_dict = {}
     

--- a/src/mini_trainer/utils.py
+++ b/src/mini_trainer/utils.py
@@ -9,6 +9,8 @@ import torch
 from torch.distributed import is_initialized, get_rank
 import torch.distributed as dist
 from rich.logging import RichHandler
+from transformers import AutoModel, AutoModelForCausalLM, AutoConfig
+from transformers.models.auto import MODEL_MAPPING, MODEL_FOR_CAUSAL_LM_MAPPING
 
 from mini_trainer.training_types import TorchrunArgs
 
@@ -121,3 +123,17 @@ def init_distributed_environment():
     log_rank_0("✅ Torch distributed appears to be functioning correctly")
 
     torch.distributed.barrier()
+
+
+def get_model_class_from_config(model_path):
+    """Get the actual model class (not just the name) from a pretrained path."""
+    # get the model class from config
+    # TODO: make the `trust_remote_code` setting configurable somehow
+    config = AutoConfig.from_pretrained(model_path, trust_remote_code=True)
+    mapping = MODEL_FOR_CAUSAL_LM_MAPPING
+
+    config_class = config.__class__
+    if config_class not in mapping:
+        raise ValueError(f"Model class {config_class} not found in mapping {mapping}")
+    return mapping[config_class]
+

--- a/tests/test_osft.py
+++ b/tests/test_osft.py
@@ -761,31 +761,47 @@ class TestSetupModelIntegration:
     """Test integration of OSFT options with setup_model function."""
     
     @patch('mini_trainer.setup_model_for_training.log_rank_0')
+    @patch('transformers.AutoConfig')
+    @patch('mini_trainer.setup_model_for_training.get_model_class_from_config')
     @patch('mini_trainer.setup_model_for_training.AutoModelForCausalLM')
     @patch('mini_trainer.setup_model_for_training.AutoTokenizer')
     @patch('mini_trainer.setup_model_for_training.AutoConfig')
     @patch('mini_trainer.osft_utils.auto_generate_target_osft_config')
-    @patch('mini_trainer.osft_utils.create_osft_model_class')
-    def test_osft_params_flow_through_setup(self, mock_osft_class, mock_auto_config, mock_transformers_auto_config, mock_tokenizer_cls, mock_model_cls, mock_log):
+    @patch('mini_trainer.setup_model_for_training.create_osft_model_class')
+    def test_osft_params_flow_through_setup(self, mock_osft_class, mock_auto_config, mock_setup_auto_config, mock_tokenizer_cls, mock_model_cls, mock_get_model_class, mock_transformers_auto_config, mock_log):
         """Test that OSFT parameters flow through the setup correctly."""
         # Test that OSFT model creation gets the right parameters
         mock_auto_config.return_value = {"layer.weight": 10}
         
-        # Mock the OSFT model class
-        mock_osft_model_cls = MagicMock()
+        # Create mock OSFT instance
         mock_osft_instance = MagicMock()
         mock_osft_instance.config = MagicMock()
         mock_osft_instance.config.vocab_size = 1000
         mock_osft_instance.dtype = torch.float32
+        mock_osft_instance.reinitialize_osft = MagicMock()
+        mock_osft_instance.named_parameters = MagicMock(return_value=[])
+        mock_osft_instance.parameters = MagicMock(return_value=[])
         
-        # Setup from_pretrained to return a properly configured model
-        def from_pretrained_side_effect(*args, **kwargs):
-            # Store the kwargs for verification
-            mock_osft_model_cls.last_kwargs = kwargs
-            return mock_osft_instance
+        # Create a function that builds the OSFT class
+        def create_mock_osft_class(base_cls):
+            class MockOSFTModelCls(base_cls):
+                last_kwargs = {}  # Store kwargs for verification
+                
+                @classmethod
+                def from_pretrained(cls, *args, **kwargs):
+                    # Store the kwargs for verification
+                    cls.last_kwargs = kwargs
+                    # Set attributes on the instance
+                    mock_osft_instance.upcast_dtype = kwargs.get('upcast_dtype', torch.float32)
+                    if 'output_dtype' in kwargs and kwargs['output_dtype'] is not None:
+                        mock_osft_instance.output_dtype = kwargs['output_dtype']
+                    return mock_osft_instance
+            
+            # Store the class for later verification
+            create_mock_osft_class.osft_class = MockOSFTModelCls
+            return MockOSFTModelCls
         
-        mock_osft_model_cls.from_pretrained.side_effect = from_pretrained_side_effect
-        mock_osft_class.return_value = mock_osft_model_cls
+        mock_osft_class.side_effect = create_mock_osft_class
         
         # Mock tokenizer and base model
         mock_tokenizer = MagicMock()
@@ -793,10 +809,28 @@ class TestSetupModelIntegration:
         mock_tokenizer.pad_token_id = 0
         mock_tokenizer_cls.from_pretrained.return_value = mock_tokenizer
         
+        # Create a proper base model class
+        class MockBaseModelClass:
+            __name__ = "LlamaForCausalLM"
+            
+            @classmethod
+            def from_pretrained(cls, *args, **kwargs):
+                # This is what super().from_pretrained() will call
+                return mock_osft_instance
+        
         mock_base_model = MagicMock()
         mock_base_model.config = MagicMock()
         mock_base_model.config.vocab_size = 1000
+        mock_base_model.__class__ = MockBaseModelClass
         mock_model_cls.from_pretrained.return_value = mock_base_model
+        
+        # Mock get_model_class_from_config to return the base model class
+        mock_get_model_class.return_value = MockBaseModelClass
+        
+        # Mock AutoConfig globally (used in osft_utils) to return a non-GPT-OSS config
+        mock_osft_config = MagicMock()
+        mock_osft_config.model_type = "llama"  # Not GPT-OSS
+        mock_transformers_auto_config.from_pretrained.return_value = mock_osft_config
         
         # Call setup_model with OSFT params
         model = setup_model(
@@ -811,10 +845,12 @@ class TestSetupModelIntegration:
         mock_osft_class.assert_called_once()
         
         # Verify from_pretrained was called with the right params
-        assert 'rank_ratio' in mock_osft_model_cls.last_kwargs
-        assert mock_osft_model_cls.last_kwargs['rank_ratio'] == 0.75
-        assert 'target_patterns' in mock_osft_model_cls.last_kwargs
-        assert mock_osft_model_cls.last_kwargs['target_patterns'] == ["custom.layer1", "custom.layer2"]
+        # Get the OSFT class that was created
+        osft_cls = create_mock_osft_class.osft_class
+        assert 'rank_ratio' in osft_cls.last_kwargs
+        assert osft_cls.last_kwargs['rank_ratio'] == 0.75
+        assert 'target_patterns' in osft_cls.last_kwargs
+        assert osft_cls.last_kwargs['target_patterns'] == ["custom.layer1", "custom.layer2"]
 
 
 class TestEndToEndOSFT:

--- a/tests/test_osft_dtype_functionality.py
+++ b/tests/test_osft_dtype_functionality.py
@@ -209,16 +209,18 @@ class TestOSFTModelDtypeIntegration:
             # Should use model's output_dtype
             assert reconstructed.dtype == torch.bfloat16
     
-    @patch('mini_trainer.osft_utils.create_osft_model_class')
+    @patch('transformers.AutoConfig')
+    @patch('mini_trainer.setup_model_for_training.create_osft_model_class')
     @patch('mini_trainer.setup_model_for_training.align_model_and_tokenizer')
     @patch('torch.distributed.is_initialized', return_value=False)
     @patch('torch.distributed.get_rank', return_value=0)
+    @patch('mini_trainer.setup_model_for_training.get_model_class_from_config')
     @patch('mini_trainer.setup_model_for_training.AutoModelForCausalLM')
     @patch('mini_trainer.setup_model_for_training.AutoTokenizer')
     @patch('mini_trainer.setup_model_for_training.AutoConfig')
     def test_setup_model_assigns_dtype_attributes(self, mock_auto_config, mock_tokenizer, mock_model_class, 
-                                                 mock_get_rank, mock_is_initialized, 
-                                                 mock_align, mock_create_osft):
+                                                 mock_get_model_class, mock_get_rank, mock_is_initialized, 
+                                                 mock_align, mock_create_osft, mock_transformers_auto_config):
         """Test that setup_model correctly assigns dtype attributes to OSFT model."""
         # Create a real object to verify attribute assignment
         class MockOSFTModel:
@@ -228,6 +230,19 @@ class TestOSFTModelDtypeIntegration:
                 self.__class__.__name__ = "LlamaForCausalLM"  # Supported model name
                 # Make reinitialize_osft a MagicMock so we can track calls
                 self.reinitialize_osft = MagicMock()
+                # Add some dummy parameters for OSFT config generation
+                self._parameters = {
+                    'model.layers.0.self_attn.q_proj.weight': torch.nn.Parameter(torch.randn(512, 512)),
+                    'model.layers.0.self_attn.v_proj.weight': torch.nn.Parameter(torch.randn(512, 512)),
+                }
+            
+            def named_parameters(self):
+                """Return dummy parameters for OSFT config generation."""
+                return self._parameters.items()
+            
+            def parameters(self):
+                """Return just the parameter values."""
+                return self._parameters.values()
             
             def to(self, device):
                 return self
@@ -235,11 +250,28 @@ class TestOSFTModelDtypeIntegration:
         # Create the mock OSFT model instance
         mock_osft_model = MockOSFTModel()
         
+        # Create a proper base model class with from_pretrained
+        class MockBaseModelClass:
+            __name__ = "LlamaForCausalLM"
+            
+            @classmethod
+            def from_pretrained(cls, *args, **kwargs):
+                # This is what super().from_pretrained() will call
+                return mock_osft_model
+        
         # Mock the temporary base model that gets created and deleted
         mock_temp_model = MagicMock()
         mock_temp_model.config = MagicMock()
-        mock_temp_model.__class__.__name__ = "LlamaForCausalLM"
+        mock_temp_model.__class__ = MockBaseModelClass
         mock_model_class.from_pretrained.return_value = mock_temp_model
+        
+        # Mock get_model_class_from_config to return the base model class
+        mock_get_model_class.return_value = MockBaseModelClass
+        
+        # Mock AutoConfig globally (used in osft_utils) to return a non-GPT-OSS config
+        mock_osft_config = MagicMock()
+        mock_osft_config.model_type = "llama"  # Not GPT-OSS
+        mock_transformers_auto_config.from_pretrained.return_value = mock_osft_config
         
         # Mock tokenizer
         mock_tokenizer_inst = MagicMock()
@@ -249,10 +281,20 @@ class TestOSFTModelDtypeIntegration:
         # Mock align_model_and_tokenizer to return the models as-is
         mock_align.side_effect = lambda model, tokenizer: model
         
-        # Mock the OSFT class creation and instantiation
-        mock_osft_class = MagicMock()
-        mock_osft_class.from_pretrained.return_value = mock_osft_model
-        mock_create_osft.return_value = mock_osft_class
+        # Mock the OSFT class creation to return a function that creates the proper class
+        def create_mock_osft_class(base_cls):
+            # Create a class that inherits from the base class
+            class MockOSFTClass(base_cls):
+                @classmethod
+                def from_pretrained(cls, *args, **kwargs):
+                    # Set the proper attributes on the model
+                    mock_osft_model.upcast_dtype = kwargs.get('upcast_dtype', torch.float32)
+                    mock_osft_model.output_dtype = kwargs.get('output_dtype', None)
+                    mock_osft_model.reinitialize_osft = MagicMock()
+                    return mock_osft_model
+            return MockOSFTClass
+            
+        mock_create_osft.side_effect = create_mock_osft_class
         
         # Call setup_model
         result = setup_model(
@@ -269,11 +311,8 @@ class TestOSFTModelDtypeIntegration:
         assert result.upcast_dtype == torch.float32
         assert result.output_dtype == torch.bfloat16
         
-        # Verify the OSFT model was created from the temporary model's class
-        mock_create_osft.assert_called_once_with(mock_temp_model.__class__)
-        
-        # Verify from_pretrained was called on the OSFT class
-        mock_osft_class.from_pretrained.assert_called_once()
+        # Verify the OSFT model was created from the base model class
+        mock_create_osft.assert_called_once_with(MockBaseModelClass)
         
         # Verify reinitialize_osft was called
         assert hasattr(result, 'reinitialize_osft')


### PR DESCRIPTION
This PR:
- decouples GPT-OSS from OSFT memory efficient loading
- ensures that only the intended params are loaded on the GPU during memory efficient loading
- ensures all param types are converted to the intended `train_dtype` regardless of the training mode
- adds epoch to the logger 